### PR TITLE
feat(security): add gitleaks secret scanning (ops #2830)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -56,7 +56,12 @@ jobs:
         run: |
           set -euo pipefail
           tgz="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          curl -sSfL -o "/tmp/${tgz}" \
+          # Retry: a transient 503 from the release CDN fails the whole
+          # gate otherwise. Observed on the very first run of this
+          # rollout. A flaky security gate gets disabled, so the
+          # download must not be the fragile part.
+          curl -sSfL --retry 3 --retry-delay 2 --retry-all-errors \
+            -o "/tmp/${tgz}" \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tgz}"
           echo "${GITLEAKS_SHA256}  /tmp/${tgz}" | sha256sum -c -
           tar -xzf "/tmp/${tgz}" -C /tmp gitleaks

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,84 @@
+name: Secret scan
+
+# ops #2830. This repository is PUBLIC and had no secret scanning of any kind
+# — no gitleaks config, no pre-commit hook, no workflow. Measured 2026-08-12
+# across the festion org: 20 of 34 active repos had no config at all, and all
+# 7 active public repos were unprotected.
+#
+# WORKING TREE ONLY (--no-git), deliberately. A history-scanning gate fails
+# forever on every future commit for a secret in an old commit, which is
+# unfixable without a history rewrite and would wedge exactly the repos that
+# most need a gate. History is a one-time audit that produces rotation work;
+# the working tree is the recurring gate. The two answer different questions
+# and neither is a superset of the other (measured on homelab-workspace: 11
+# working-tree findings vs 38 in history, overlapping on 2).
+#
+# --redact is correct HERE and wrong for triage: it replaces every finding's
+# secret with the literal string REDACTED, which is what you want in a public
+# CI log and actively misleading if you are reasoning about the findings. Run
+# without it locally when investigating.
+#
+# NOTE: a green run means "no rule matched", not "this repo is clean".
+# Rule-based scanning structurally misses a credential written in prose or a
+# plain high-entropy string with no recognisable prefix (ops #2832).
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The binary, not gitleaks/gitleaks-action: festion is a GitHub
+      # Organization, and that action requires a paid GITLEAKS_LICENSE for
+      # org-owned repos. It would fail closed on every run.
+      #
+      # Version pinned and checksum-verified. Pinned because the rollout was
+      # verified against exactly this version; bumping it changes detection
+      # behaviour and should be a deliberate, re-verified change. Verified
+      # because downloading an unpinned binary and executing it in CI is a
+      # supply-chain hole, and this job exists to close security gaps.
+      - name: Install gitleaks (pinned, checksum-verified)
+        env:
+          GITLEAKS_VERSION: 8.21.2
+          GITLEAKS_SHA256: >-
+            5bc41815076e6ed6ef8fbecc9d9b75bcae31f39029ceb55da08086315316e3ba
+        run: |
+          set -euo pipefail
+          tgz="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL -o "/tmp/${tgz}" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tgz}"
+          echo "${GITLEAKS_SHA256}  /tmp/${tgz}" | sha256sum -c -
+          tar -xzf "/tmp/${tgz}" -C /tmp gitleaks
+          chmod +x /tmp/gitleaks
+          /tmp/gitleaks version
+
+      # A scan that silently fails to run exits 0 and looks identical to a
+      # clean repo. This asserts the config is present and parses BEFORE the
+      # real scan, so "no leaks found" cannot mean "no config was loaded".
+      - name: Verify the config is present and loadable
+        run: |
+          set -euo pipefail
+          test -f .gitleaks.toml || {
+            echo "FATAL: .gitleaks.toml missing — a scan without it would"
+            echo "silently fall back to default rules and still exit 0."
+            exit 1
+          }
+          /tmp/gitleaks detect --source . --no-git --config .gitleaks.toml \
+            --exit-code 0 --log-level error --report-path /dev/null
+          echo "config loads and the scanner runs"
+
+      - name: Scan working tree
+        run: |
+          /tmp/gitleaks detect --source . --no-git --config .gitleaks.toml \
+            --redact --exit-code 1 --log-level info

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,240 @@
+# Shared gitleaks config for the homelab monorepo.
+#
+# Companion to: operations/docs/plans/2026-05-08-monorepo-security-remediation.md
+# Author: Task 22 (Vikunja #1073).
+#
+# Each repo's `.gitleaks.toml` is a verbatim copy of this file.
+# To update centrally: edit `operations/templates/gitleaks/.gitleaks.toml`,
+# then re-roll via the per-repo procedure in the README.
+#
+# Rule shapes are tuned to the literals found in the 2026-05-08 audit:
+#   - HA long-lived JWTs (eyJ... with iss/iat/exp claims)
+#   - Proxmox / PBS API tokens (`PVEAPIToken=…`, `PBSAPIToken=…`)
+#   - NetBox 40-char hex tokens
+#   - Pushover app/user tokens (30-char alnum)
+#   - TrueNAS API keys (numeric-id-prefixed: `<id>-<base64ish>`)
+#   - generic JWT shape, PEM private keys, AWS keys
+
+title = "Homelab monorepo gitleaks config"
+
+[extend]
+# Pull in gitleaks' upstream defaults (covers AWS, GCP, Stripe, etc.).
+useDefault = true
+
+# ---------------------------------------------------------------------------
+# Custom rules
+# ---------------------------------------------------------------------------
+
+[[rules]]
+id = "ha-long-lived-token"
+description = "Home Assistant long-lived access token (JWT with iss claim)"
+# JWTs are header.payload.signature, all base64url. The HA-specific tells are
+# `iss`, `iat`, `exp` claims after a permissive header. Keep the regex narrow
+# enough that arbitrary base64 blobs don't trip it.
+regex = '''eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{40,}\.[A-Za-z0-9_-]{20,}'''
+keywords = ["eyJ"]
+
+[[rules]]
+id = "proxmox-pve-api-token"
+description = "Proxmox VE API token (`PVEAPIToken=user@realm!tokenid=uuid`)"
+# Token format: PVEAPIToken=user@realm!tokenid=<uuid-secret>
+regex = '''PVEAPIToken=[A-Za-z0-9._@-]+![A-Za-z0-9._-]+=[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'''
+keywords = ["PVEAPIToken="]
+
+[[rules]]
+id = "pbs-api-token"
+description = "Proxmox Backup Server API token (`PBSAPIToken=user@realm!tokenid:uuid`)"
+# PBS uses `:` as the separator between tokenid and secret (PVE uses `=`).
+regex = '''PBSAPIToken=[A-Za-z0-9._@-]+![A-Za-z0-9._-]+:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'''
+keywords = ["PBSAPIToken="]
+
+[[rules]]
+id = "pbs-token-id-with-uuid-secret"
+description = "PBS token id with adjacent UUID secret (`monitor@pbs!name:uuid` shape)"
+# Catches the bare-token shape that appeared in proxmox-agent docs / configs:
+#   monitor@pbs!agent:8a14ef79-1a2b-4c5d-...
+# Matches @pbs! plus a UUID v4 within ~80 chars.
+regex = '''[A-Za-z0-9._-]+@pbs![A-Za-z0-9._-]+[:= ]\s*[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'''
+keywords = ["@pbs!"]
+
+[[rules]]
+id = "pve-token-id-with-uuid-secret"
+description = "PVE token id with adjacent UUID secret (`api@pve!homepage=uuid` shape)"
+regex = '''[A-Za-z0-9._-]+@pve![A-Za-z0-9._-]+[:= ]\s*[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'''
+keywords = ["@pve!"]
+
+[[rules]]
+id = "netbox-api-token"
+description = "NetBox API token (40 hex chars, often after `Token ` or in a config field)"
+# NetBox tokens are 40 lowercase-hex. Require an anchor word to keep noise low.
+regex = '''(?i)(netbox[_-]?(api[_-]?)?token|netbox.*authorization)["'\s:=]+[a-f0-9]{40}\b'''
+keywords = ["netbox"]
+
+[[rules]]
+id = "pushover-app-token"
+description = "Pushover application token (30-char alnum, prefixed with `a`)"
+# Pushover app tokens start with 'a' and are 30 chars total. User keys start
+# with 'u' and are also 30 chars. Anchor on the keyword to avoid noise.
+regex = '''(?i)(pushover[_-]?(api[_-]?)?(token|key))["'\s:=]+[aug][a-zA-Z0-9]{29}\b'''
+keywords = ["pushover"]
+
+[[rules]]
+id = "truenas-api-key"
+description = "TrueNAS API key (id-prefixed: `<n>-<60+ alnum>`)"
+# Format: `<numeric_id>-<base64ish-60-chars>`. Anchor on context so we don't
+# false-positive on every dashed identifier.
+regex = '''(?i)(truenas[_-]?(api[_-]?)?key|HOMEPAGE_VAR_TRUENAS_KEY)["'\s:=]+[0-9]+-[A-Za-z0-9]{60,}\b'''
+keywords = ["truenas", "HOMEPAGE_VAR_TRUENAS_KEY"]
+
+[[rules]]
+id = "private-key-pem"
+description = "Private key PEM block (RSA, EC, OpenSSH, generic)"
+regex = '''-----BEGIN ((RSA|EC|DSA|OPENSSH|PGP) )?PRIVATE KEY( BLOCK)?-----'''
+keywords = ["BEGIN", "PRIVATE KEY"]
+
+[[rules]]
+id = "anthropic-api-key"
+description = "Anthropic API key (`sk-ant-api03-…` and similar version prefixes)"
+# Format: `sk-ant-api<N>-` then ~95 chars base64url. Self-anchored — no
+# keyword needed; the prefix is unique enough not to false-positive.
+regex = '''sk-ant-api\d{2,}-[A-Za-z0-9_-]{90,}'''
+keywords = ["sk-ant-api"]
+
+[[rules]]
+id = "generic-bearer-token"
+description = "Generic bearer / authorization with long secret"
+# Loose match for `Authorization: Bearer <60+ chars>` or `auth_token = <secret>`.
+# `\b` prefix prevents matches on camelCase identifiers like `authenticateApiKey`
+# (no word boundary inside camelCase). Keyword list reduces noise further.
+regex = '''(?i)\b(authorization|bearer|api[_-]?token|api[_-]?key|access[_-]?token)["'\s:=]+[A-Za-z0-9._\-]{40,}\b'''
+keywords = ["authorization", "bearer", "api_token", "api-token", "apikey", "api_key", "access_token"]
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+#
+# Per-line opt-out: append `# gitleaks:allow` to a line to silence ALL rules
+# on that single line. Use sparingly and ALWAYS leave a comment explaining why
+# the match is a false positive (e.g. test fixture, public sample, doc example).
+#
+# Path-level opt-outs go below.
+
+[allowlist]
+description = "Global allowlist for known-safe paths and test fixtures"
+
+# Files that cannot meaningfully contain secrets but trigger heuristics.
+# Path regexes match against the file path *relative to the repo root*.
+paths = [
+  '''(?i)(^|/)CHANGELOG(\.md)?$''',
+  '''(?i)(^|/)LICENSE(\.md|\.txt)?$''',
+  '''(?i)(^|/)\.gitleaks\.toml$''',
+  '''(?i)(^|/)\.gitleaksignore$''',
+  '''(?i)(^|/)go\.sum$''',
+  '''(?i)(^|/)package-lock\.json$''',
+  '''(?i)(^|/)pnpm-lock\.yaml$''',
+  '''(?i)(^|/)yarn\.lock$''',
+  '''(?i)(^|/)poetry\.lock$''',
+  '''(?i)(^|/)Pipfile\.lock$''',
+  '''(?i)(^|/)uv\.lock$''',
+  # The gitleaks template itself contains rule regexes that would self-match.
+  '''(?i)(^|/)templates/gitleaks/''',
+  # Heavy gitignored dirs that bypass-scans (`gitleaks detect --no-git
+  # --source .`) would otherwise traverse. The pre-commit hook never sees
+  # these files (gitignored = never staged), so allowlisting here keeps
+  # ad-hoc baseline scans noise-free without weakening commit-time defense.
+  '''(^|/)\.serena/cache/''',
+  '''(^|/)\.serena/memories/.*/cache/''',
+  '''(^|/)\.storage/''',                       # Home Assistant runtime store
+  '''(^|/)\.esphome/''',                       # ESPHome build cache
+  '''(^|/)esphome/\.esphome/''',
+  '''(^|/)esphome/build/''',
+  '''(^|/)secrets\.yaml$''',                   # local-only HA secrets file (gitignored)
+  '''(^|/)secrets\.yml$''',
+  '''(^|/)\.env$''',                           # gitignored env files; never staged
+  '''(^|/)\.env\.(local|prod|production|development|dev|staging|test)$''',
+  # Template / example env files — inherently full of placeholders.
+  # `.env.example`, `.env.sample`, `.env.template` etc.
+  '''(^|/)\.env\.(template|example|sample|dist|defaults?)$''',
+  # Test directories — fixtures inevitably carry token-shaped strings.
+  '''(^|/)tests?/''',
+  '''(^|/)__tests__/''',
+  '''(^|/)spec/''',
+  '''(^|/)\.jest-cache[^/]*/''',                # Jest transform / haste-map caches
+  '''\.pkl$''',                                # pickle binaries (Serena)
+  '''\.log$''',                                # log files
+  '''(^|/)home-assistant\.log''',
+  '''(^|/)dist/''',                            # built artifacts
+  '''(^|/)build/''',
+  '''(^|/)node_modules/''',
+  '''(^|/)__pycache__/''',
+  '''\.pyc$''',
+]
+
+# Stop matches that are obviously placeholder / docs / test fixtures.
+# Each entry is a regex that, if it matches the LINE (not just the match),
+# suppresses the finding.
+regexes = [
+  # Test-fixture UUIDs (zero-uuid, all-f-uuid).
+  '''00000000-0000-0000-0000-000000000000''',
+  '''ffffffff-ffff-ffff-ffff-ffffffffffff''',
+  # Common doc placeholders.
+  '''(?i)<your[_-]?(token|key|password|secret)>''',
+  '''(?i)REPLACE[_-]?ME''',
+  '''(?i)example[_-]?(token|key|secret)''',
+  '''xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx''',
+  # Bare upper-snake placeholder words used in shell/curl examples
+  # ("Authorization: Token YOUR_TOKEN" etc.). `_HERE` and `_<vendor>_<TYPE>`
+  # tails are common (YOUR_TOKEN_HERE, YOUR_WIKIJS_TOKEN, YOUR_CLOUDFLARE_KEY).
+  '''\bYOUR_(TOKEN|KEY|API_KEY|API_TOKEN|PASSWORD|SECRET|ACCESS_TOKEN)(_HERE|_VALUE)?\b''',
+  '''\bYOUR_[A-Z][A-Z0-9_]+(_TOKEN|_KEY|_PASSWORD|_SECRET)\b''',
+  '''\b(MY_|FAKE_|DUMMY_|PLACEHOLDER_|TEST_|EXAMPLE_)(TOKEN|KEY|API_KEY|PASSWORD|SECRET)\b''',
+  # Bare `PASSWORD` / `TOKEN` etc. in shell-quoted creds: `-u "root:PASSWORD"`.
+  '''[':"]\s*(USERNAME|USER|PASSWORD|PASS|TOKEN|KEY|SECRET)\s*[':"]''',
+  # Truncated-with-ellipsis JWT/Infisical placeholders in docs.
+  # `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` — canonical HS256 JWT header,
+  # ellipsis-truncated. Same pattern handles other JWT placeholders.
+  '''eyJ[A-Za-z0-9_-]+\.\.\.''',
+  # `eyJ...` JWTs with `alg:none` test fixtures (3 dots literal then trailing).
+  '''eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.\s*['"]''',
+  # Infisical service token placeholder (`st.<uuid>...` or `st.your-token`).
+  '''st\.[0-9a-f-]{0,36}\.\.\.''',
+  '''st\.your-token''',
+  '''st\.<[^>]+>''',
+  # Sequential-digit GitHub PAT placeholder (`ghp_1234567890abcdef...`).
+  '''ghp_1234567890[a-f0-9]+''',
+  # Cloudflare token placeholder shape used by Traefik docs.
+  '''hga_your_api_key_here''',
+  # Documented example curl credentials — weak placeholder passwords in docs
+  # (`curl -u admin:proxmox123`, `root:changeme`). Never real; a genuine
+  # leaked cred would not be one of these throwaway example values. (#1999)
+  '''(?i)\b(admin|root|user):(proxmox123|password|passwd|changeme|example|placeholder|test)\b''',
+  # Stripe-style placeholder API keys in docs (`sk_live_abc123...`,
+  # `sk_test_...`). Real Stripe keys are 24+ random chars with no
+  # `abc123`/ellipsis tell. (#1999)
+  '''sk_(live|test)_[A-Za-z0-9]*\.\.\.''',
+  '''sk_(live|test)_(abc123|xxx|placeholder|example|your)[A-Za-z0-9]*''',
+  # Angle-bracket placeholders standardized in our 2026-05-08 rotation work.
+  # Catches `<OLD_…>`, `<NEW_…>`, `<SEE_INFISICAL:…>`, `<LAKEHOUSE_…>`,
+  # `<WIKI_…>`, etc. — explicit upper-snake placeholder shape.
+  '''<[A-Z][A-Z0-9_]+(:[^>]+)?>''',
+  # Older convention.
+  '''<see Infisical:''',
+
+  # ── REPO-LOCAL (ops #2830) ─────────────────────────────────────────────
+  # html/cert_form.htm line 31 is a `<textarea placeholder="-----BEGIN
+  # PRIVATE KEY-----">` in the upstream certificate-UPLOAD form. The literal
+  # PEM header is the placeholder text of an empty input, not key material.
+  # Verified by measurement rather than assumption: that line contains ZERO
+  # base64 runs of 20+ chars, and no line in the whole 37-line file contains
+  # a 40+ char base64 run, which real key material necessarily would.
+  # Matched on the LINE, deliberately narrower than allowlisting the path —
+  # a real key pasted into this file would still be caught.
+  # The captured SECRET is an EMPTY PEM envelope -- a BEGIN header, optional
+  # whitespace, optional END footer, and NO base64 body. Real key material
+  # cannot match this. Written against the SECRET, not the line: this
+  # template sets no `regexTarget`, so gitleaks matches allowlist regexes
+  # against the captured secret. (The comment above the regexes block says
+  # "matches the LINE" -- that is inaccurate; a line-shaped entry silently
+  # never fires. Filed separately.)
+  '''^-----BEGIN [A-Z ]+-----\s*(-----END [A-Z ]+-----)?\s*$''',
+]


### PR DESCRIPTION
This repo is **public** and had no secret scanning of any kind (ops #2830: 20 of 34 active festion repos had no config; all 7 active public repos unprotected).

## Baseline was 2 findings — both benign

Both in `html/cert_form.htm` line 31:

```html
<textarea id="client-key" ... placeholder="-----BEGIN PRIVATE KEY-----">
```

The captured "secrets" are the literal PEM header text used as the placeholder of an **empty upload field** — 27 chars (`-----BEGIN PRIVATE KEY-----`) and 53 (that plus the END footer).

**Established by measurement, not by reading the code and assuming:** both captures contain **zero** base64 runs of 20+ chars, and **no line in the whole 37-line file** contains a 40+ char base64 run, which real key material necessarily would.

## The allowlist is deliberately narrow — and verified so

It matches an **empty PEM envelope** (BEGIN header, optional whitespace, optional END footer, no body), *not* the file path. With the entry in place:

| planted in that same file | result |
|---|---|
| real PEM key **with a body** | **detected** (`private-key`) |
| `sk-ant-` key | **detected** (`anthropic-api-key`) |

Allowlisting the path would have silenced both.

## A template bug found on the way

The comment above the template's `regexes` block says entries match *"the LINE (not just the match)"*. That is **inaccurate** — no `regexTarget` is set, so gitleaks matches allowlist regexes against the captured **secret**. A line-shaped entry silently never fires; I wrote one first and it suppressed nothing. Worth fixing in `operations/templates/gitleaks/`.

## Design decisions

Working-tree-only scan, GitHub-hosted runners (free for public repos; self-hosted + `pull_request` on a public repo lets fork PRs run code on your infrastructure, ops #2341), pinned + checksum-verified binary rather than `gitleaks-action` (needs a paid licence for org-owned repos), and a pre-flight config-loadability assert so a silently-unloaded config can't look like a clean repo. All documented in the workflow file.

A green run means "no rule matched", **not** "this repo is clean" (ops #2832).

🤖 Generated with [Claude Code](https://claude.com/claude-code)