### PR TITLE
fix(gitleaks): scope the PEM exemption to the one file that needs it (ops #2897)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -283,6 +283,19 @@ paths = [
   '''(^|/)node_modules/''',
   '''(^|/)__pycache__/''',
   '''\.pyc$''',
+  # html/cert_form.htm is a static upload form whose <textarea placeholder="...">
+  # shows an EMPTY PEM block as UI hint text (BEGIN on one line, END on the next,
+  # no key material). It tripped private-key-pem and gitleaks' default private-key.
+  #
+  # This replaces a blanket VALUE regex ('^-----BEGIN [A-Z ]+-----...$') that read as
+  # "allow an empty PEM block" but did far more: private-key-pem captures ONLY the
+  # header line, and gitleaks matches allowlist regexes against the CAPTURED SECRET,
+  # so that entry matched EVERY private-key finding in this repo regardless of key
+  # material. Measured (ops #2897): a planted PEM with a real OPENSSH body was
+  # suppressed too. A value regex cannot distinguish empty from populated here,
+  # because the capture is the header either way -- so the exemption is scoped by
+  # PATH instead, to the single 37-line file that needed it.
+  '''(^|/)html/cert_form\.htm$''',
 ]
 
 # Stop matches that are obviously placeholder / docs / test fixtures.
@@ -388,5 +401,4 @@ regexes = [
   # against the captured secret. (The comment above the regexes block says
   # "matches the LINE" -- that is inaccurate; a line-shaped entry silently
   # never fires. Filed separately.)
-  '''^-----BEGIN [A-Z ]+-----\s*(-----END [A-Z ]+-----)?\s*$''',
 ]


### PR DESCRIPTION
**This repo could not report a private key at all.** Its local allowlist carried:

```
'''^-----BEGIN [A-Z ]+-----\s*(-----END [A-Z ]+-----)?\s*$'''
```

which reads as *"allow an empty PEM block"* — and was surely written for exactly that. But `private-key-pem` captures **only the header line**, and gitleaks matches allowlist regexes against the **captured secret**. So that entry matched **every** private-key finding in this repo, regardless of whether key material followed.

## Measured, with a control

```
planted PEM with a real OPENSSH body, this repo's config  -> SUPPRESSED
planted PEM with a real OPENSSH body, shared template     -> DETECTED
```

Same sample, same rule, one difference: the local entry. The template arm is the control — it proves the sample is detectable and that the suppression is this repo's, not the sample's.

**No value regex can fix this**, because the capture is the header whether the block is empty or populated. That is why the exemption is scoped by **path** instead.

## What it was actually protecting

`html/cert_form.htm` — a 37-line static upload form whose `<textarea placeholder="...">` shows an empty PEM block as UI hint text (`BEGIN` on one line, `END` on the next). Confirmed benign **before** reading the file: zero base64 runs ≥40 chars in that line or the following five. It tripped both `private-key-pem` and gitleaks' default `private-key`.

The entry is replaced by a path exemption for that one file, with the reasoning recorded inline so the next person does not re-widen it.

## Acceptance — both arms

The second arm is what stops this being *"delete the entry and accept a red gate"*:

```
a PEM with a real key body planted in this tree  -> REPORTED (private-key-pem
                                                    AND gitleaks' private-key)
the cert_form.htm placeholder                    -> still silent
repo tree                                        -> 0 findings
canary suite                                     -> 21/21  (was 19/21)
rules vs template                                -> identical, 0 entries dropped
```

## How it was found

By adding a **second canary per rule** to the ops #2830 suite. Set A planted a bare PEM header; this repo scored 9/10 and the available reading was benign — *"allows empty PEM headers"* — which is what I wrote on its sync PR. Set B planted a header **with a body**, and the answer turned out to be *"cannot see private keys"*.

A canary suite proves a rule can fire for the shapes you thought of; an allowlist is precisely a claim about the shapes you did not.

## Not done

- **No private key is known to be committed here.** This is a detection blindness, not a leak — but the repo would have scanned clean either way, which is the point.
- This is `--no-git` working-tree only, matching the CI gate. Nothing is claimed about this repo's **history**, which is a different scan and would be the natural follow-up given the rule was blind for as long as the entry existed.
- The path exemption disables **all** rules for `html/cert_form.htm`. That is acceptable for a static form with no secrets and is far narrower than what it replaces, but it is a real trade and is stated rather than buried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
