### PR TITLE
chore(gitleaks): sync .gitleaks.toml to the operations template (ops #2830)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,8 +4,25 @@
 # Author: Task 22 (Vikunja #1073).
 #
 # Each repo's `.gitleaks.toml` is a verbatim copy of this file.
-# To update centrally: edit `operations/templates/gitleaks/.gitleaks.toml`,
-# then re-roll via the per-repo procedure in the README.
+#
+# TO UPDATE CENTRALLY: edit this file and merge. The fan-out is AUTOMATED as of
+# ops #2958 — homelab-iac's weekly `gitleaks-fleet-sync-watch.py` surveys every
+# gated repo and opens a sync PR on each one that has fallen behind. It opens
+# PRs and merges nothing, so the review gate is unchanged, and it skips a repo
+# that already has one open, so an unmerged PR is not reopened weekly.
+#
+# Do NOT hand-copy this file into a repo. `sync_gitleaks_fleet.py` performs a
+# MERGE, not a copy: repo-local allowlist entries (ESPHome's CI dummy key,
+# gw4-config-tool's cert fixture, four in birdnet-gone) are preserved with their
+# comments. A `cp` deletes them, and the symptom is that repo's CI going red on
+# a known-safe fixture — which is the pressure that gets a gate disabled.
+#
+# Until ops #2958 the fan-out was manual and it decayed twice in three days:
+# ops #2881 fixed two rules here and every copy kept the gap; ops #2874 moved
+# the anthropic floor and 23 of 32 repos were still blind the next morning.
+# A stale detector fails in the reassuring direction — gitleaks exits 0, CI is
+# green, and "no leaks found" means "none of the kinds this copy still knows
+# about". That is why the fan-out is scheduled rather than remembered.
 #
 # Rule shapes are tuned to the literals found in the 2026-05-08 audit:
 #   - HA long-lived JWTs (eyJ... with iss/iat/exp claims)


### PR DESCRIPTION
Re-syncs `.gitleaks.toml` to `festion/operations:templates/gitleaks/.gitleaks.toml`.

The template is distributed by **verbatim copy**, so merging a change to it
fixes the template and none of the copies that actually run. The weekly
`gitleaks-fleet-drift-watch.py` reports that drift and fixes nothing. This PR is
the fix half, generated by `operations:scripts/sync_gitleaks_fleet.py` (ops #2830).

**This is not a `cp`.** Any allowlist entry this repo has and the template does
not is preserved verbatim, with its comments, under a marked block — dropping
one would turn CI red on a known-safe fixture, which is the pressure that gets a
gate disabled. The generator asserts, per repo, that every pre-existing entry
survives, and refuses outright if the repo declares a rule id the template lacks
(dropping a *detector* fails in the reassuring direction — see ops #2824).

**What a green Secret scan on this PR does and does not mean:** it means the new
config parses and finds nothing in this tree. It says nothing about the class of
credential this sync exists to catch — a rule floor that was too high found
nothing before the change either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
